### PR TITLE
Windows support.  Path delimiter support.

### DIFF
--- a/src/load_routes.js
+++ b/src/load_routes.js
@@ -27,8 +27,8 @@ const parseDefinitions = (module, rootPath, filePath) => {
     const def = module[key];
 
     // this needs to be any folders below {root}/routes so we can match that structure in the url
-    const relativePath = filePath.replace(rootPath, '')
-      .replace('/routes', '')
+    const relativePath = filePath.replace(rootPath.replace(/\\/g, '/'), '')
+      .replace(/\/routes/, '')
       .replace(path.basename(filePath), '');
 
     return {


### PR DESCRIPTION
The rootPath can contain either \ or / 

On Windows, the slashes are inconsistent depending on how you fetch them.   You can't trust the fs module either.  

This just crushes it all to be / for consistency. 