### PR TITLE
Loosen up request schema type checking

### DIFF
--- a/src/load_routes.js
+++ b/src/load_routes.js
@@ -100,7 +100,7 @@ const disableAdditionalProperties = schema => {
 };
 
 const addRequestSchemaValidation = routes => {
-  const ajv = new Ajv({removeAdditional: true, allErrors: true});
+  const ajv = new Ajv({removeAdditional: true, allErrors: true, coerceTypes: true});
 
   _.forEach(routes, route => {
     const {implementation, verb} = route;


### PR DESCRIPTION
Allow Ajv to coerce types (e.g. convert strings to numbers)